### PR TITLE
feat(frontend): 認証画面の作成

### DIFF
--- a/frontend/where_child_bus/lib/app.dart
+++ b/frontend/where_child_bus/lib/app.dart
@@ -15,38 +15,33 @@ class _AppState extends State<App> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-        title: 'WhereChildBus',
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-          useMaterial3: true,
-        ),
-        home: Scaffold(
-            appBar: AppBar(
-              title: Text(['園児一覧', '送迎バスコース一覧', '連絡情報設定'][_selectedIndex]),
-            ),
-            body: [
-              const StudentListPage(),
-              const BusListPage(),
-              const NotificationPage()
-            ][_selectedIndex],
-            bottomNavigationBar: BottomNavigationBar(
-              currentIndex: _selectedIndex,
-              onTap: (int index) => setState(() => _selectedIndex = index),
-              items: const <BottomNavigationBarItem>[
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.people),
-                  label: '園児一覧',
-                ),
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.directions_bus),
-                  label: '送迎バスコース一覧',
-                ),
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.notifications),
-                  label: '連絡情報設定',
-                ),
-              ],
-            )));
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(['園児一覧', '送迎バスコース一覧', '連絡情報設定'][_selectedIndex]),
+      ),
+      body: [
+        const StudentListPage(),
+        const BusListPage(),
+        const NotificationPage()
+      ][_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: (int index) => setState(() => _selectedIndex = index),
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.people),
+            label: '園児一覧',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.directions_bus),
+            label: '送迎バスコース一覧',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.notifications),
+            label: '連絡情報設定',
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/frontend/where_child_bus/lib/main.dart
+++ b/frontend/where_child_bus/lib/main.dart
@@ -15,6 +15,13 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
-    return const App();
+    return MaterialApp(
+      title: 'WhereChildBus',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: const App(),
+    );
   }
 }

--- a/frontend/where_child_bus/lib/main.dart
+++ b/frontend/where_child_bus/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:where_child_bus/app.dart';
 
 void main() {
-  runApp(const App());
+  runApp(const MyApp());
 }
 
 class MyApp extends StatefulWidget {

--- a/frontend/where_child_bus/lib/pages/auth_page/auth_page.dart
+++ b/frontend/where_child_bus/lib/pages/auth_page/auth_page.dart
@@ -14,11 +14,10 @@ class _AuthPageState extends State<AuthPage> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: GestureDetector(
-        onTap: () => FocusScope.of(context).unfocus(),
-        child: Scaffold(
-            body: Center(
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: Scaffold(
+        body: Center(
           child: Padding(
             padding: const EdgeInsets.all(32),
             child: Column(
@@ -64,11 +63,11 @@ class _AuthPageState extends State<AuthPage> {
                     },
                     child: const Text('ログイン'),
                   ),
-                ),
+                )
               ],
             ),
           ),
-        )),
+        ),
       ),
     );
   }

--- a/frontend/where_child_bus/lib/pages/auth_page/auth_page.dart
+++ b/frontend/where_child_bus/lib/pages/auth_page/auth_page.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class AuthPage extends StatefulWidget {
+  const AuthPage({super.key});
+
+  @override
+  State<AuthPage> createState() => _AuthPageState();
+}
+
+class _AuthPageState extends State<AuthPage> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: GestureDetector(
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: Scaffold(
+            body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(32),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                const Text(
+                  'WhereChildBus',
+                  style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 32),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: TextField(
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: 'メールアドレス',
+                    ),
+                    controller: _emailController,
+                    keyboardType: TextInputType.emailAddress,
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: TextField(
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: 'パスワード',
+                    ),
+                    controller: _passwordController,
+                    obscureText: true,
+                    keyboardType: TextInputType.visiblePassword,
+                  ),
+                ),
+                const SizedBox(height: 32),
+                SizedBox(
+                  width: MediaQuery.of(context).size.width * 0.6,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      if (kDebugMode) {
+                        debugPrint("email: ${_emailController.text}");
+                        debugPrint("password: ${_passwordController.text}");
+                      }
+                    },
+                    child: const Text('ログイン'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        )),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## チケットへのリンク

- https://github.com/orgs/GreenTeaProgrammers/projects/2/views/1?pane=issue&itemId=52852798

## やったこと

- 認証画面の作成

## やらないこと

- 実際の認証処理
- 認証後のページ遷移

## できるようになること（ユーザ目線）

- 認証情報の入力のみ

## できなくなること（ユーザ目線）

なし

## 動作確認

- [x] `main.dart` の`_MyAppState` で `AuthPage` を呼び、認証の入力ができること

## その他

- 上記の通り、`App` を呼ばずに `AuthPage` を呼ぶことで動作確認をする
