### PR TITLE
feat:保護者側デイリービューの画面を実装

### DIFF
--- a/frontend/where_child_bus_guardian/lib/components/utils/current_time_body.dart
+++ b/frontend/where_child_bus_guardian/lib/components/utils/current_time_body.dart
@@ -4,10 +4,10 @@ import 'current_time_widget.dart';
 class CurrentTimeBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-        height: MediaQuery.of(context).size.height * 0.2,
+    return SizedBox(
+        height: MediaQuery.of(context).size.height * 0.15,
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.end,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Text(
               "現在時刻",

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/components/daily_record_body.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/components/daily_record_body.dart
@@ -13,7 +13,7 @@ class DailyRecordBody extends StatefulWidget {
 class _DailyRecordBody extends State<DailyRecordBody> {
   //TODO: 将来的にChild型を受け取る
   var isBoarding = true;
-  var hasBag = true;
+  var hasBag = false;
   var hasLunchBox = true;
   var hasWaterBottle = true;
   var hasUmbrella = true;
@@ -116,16 +116,25 @@ class _DailyRecordBody extends State<DailyRecordBody> {
   }
 
   Widget itemText(String itemName, bool hasItem) {
-    return Container(
+    return SizedBox(
         width: MediaQuery.of(context).size.width * 0.24,
-        decoration: statusFieldDecoration(hasItem),
         child: Padding(
-          padding: const EdgeInsets.only(top: 10.0, bottom: 10.0),
-          child: Text(
-            itemName,
-            style: statusFieldTextStyle(hasItem),
-            textAlign: TextAlign.center,
-          ),
-        ));
+            padding: const EdgeInsets.only(top: 5.0, bottom: 5.0),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 20,
+                  child: hasItem
+                      ? const Icon(Icons.check, color: Colors.green)
+                      : const Icon(Icons.error_outline, color: Colors.red),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  itemName,
+                  style: statusFieldTextStyle(hasItem),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            )));
   }
 }

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/components/daily_record_body.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/components/daily_record_body.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import '../styles/styles.dart';
+
+class DailyRecordBody extends StatefulWidget {
+  final String childName;
+
+  const DailyRecordBody({super.key, required this.childName});
+
+  @override
+  State<DailyRecordBody> createState() => _DailyRecordBody();
+}
+
+class _DailyRecordBody extends State<DailyRecordBody> {
+  //TODO: 将来的にChild型を受け取る
+  var isBoarding = true;
+  var hasBag = true;
+  var hasLunchBox = true;
+  var hasWaterBottle = true;
+  var hasUmbrella = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        childFaceAndExpression(),
+        Padding(
+            padding: const EdgeInsets.only(top: 20, bottom: 10),
+            child: Text(
+              widget.childName,
+              style: TextStyle(fontSize: 24),
+              textAlign: TextAlign.center,
+            )),
+        statusIconAndStatusField(
+            Icons.directions_bus, isBoardingStatusField(context)),
+        statusIconAndStatusField(Icons.business_center, childItemList(context)),
+      ],
+    );
+  }
+
+  Widget childFaceAndExpression() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: <Widget>[childFaceImage(), childExpressionIcon()],
+    );
+  }
+
+  //TODO: 将来的に画像を受け取る
+  Widget childFaceImage() {
+    return const SizedBox(
+      width: 150,
+      height: 150,
+      child: Card(
+        color: Colors.grey,
+        child: Text("ここに子供の写真が入る"),
+      ),
+    );
+  }
+
+  //TODO: 将来的に表情を受け取り、アイコンを表示する
+  Widget childExpressionIcon() {
+    return const SizedBox(
+      width: 100,
+      height: 100,
+      child: Card(
+        color: Colors.grey,
+        child: Text("ここに表情のアイコンが入る"),
+      ),
+    );
+  }
+
+  Widget statusIconAndStatusField(IconData icon, Widget statusField) {
+    return SizedBox(
+        width: MediaQuery.of(context).size.width * 0.9,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: <Widget>[
+            Icon(
+              icon,
+              size: 80,
+            ),
+            statusField,
+          ],
+        ));
+  }
+
+  Widget isBoardingStatusField(context) {
+    return Container(
+      width: MediaQuery.of(context).size.width * 0.5,
+      decoration: statusFieldDecoration(!isBoarding),
+      child: Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Text(
+            isBoarding ? "乗車中" : "降車済",
+            style: statusFieldTextStyle(!isBoarding),
+            textAlign: TextAlign.center,
+          )),
+    );
+  }
+
+  Widget childItemList(BuildContext context) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width * 0.5,
+      child: Wrap(
+        direction: Axis.horizontal,
+        alignment: WrapAlignment.spaceBetween,
+        runAlignment: WrapAlignment.spaceBetween,
+        runSpacing: 4.0,
+        children: [
+          itemText("かばん", hasBag),
+          itemText("お弁当", hasLunchBox),
+          itemText("水筒", hasWaterBottle),
+          itemText("傘", hasUmbrella),
+        ],
+      ),
+    );
+  }
+
+  Widget itemText(String itemName, bool hasItem) {
+    return Container(
+        width: MediaQuery.of(context).size.width * 0.24,
+        decoration: statusFieldDecoration(hasItem),
+        child: Padding(
+          padding: const EdgeInsets.only(top: 10.0, bottom: 10.0),
+          child: Text(
+            itemName,
+            style: statusFieldTextStyle(hasItem),
+            textAlign: TextAlign.center,
+          ),
+        ));
+  }
+}

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/components/daily_record_slider.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/components/daily_record_slider.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:where_child_bus_guardian/pages/daily_page/components/daily_record_body.dart';
+
+class DailyRecordSlider extends StatefulWidget {
+  final List<String> childNames;
+
+  const DailyRecordSlider({super.key, required this.childNames});
+
+  @override
+  State<DailyRecordSlider> createState() => _DailyRecordSlider();
+}
+
+class _DailyRecordSlider extends State<DailyRecordSlider> {
+  int currentIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> recordList = widget.childNames.map((childName) {
+      return DailyRecordBody(childName: childName);
+    }).toList();
+
+    return Column(
+      children: [
+        recordCarouselSlider(recordList),
+        const SizedBox(height: 10),
+        dotIndicator(recordList)
+      ],
+    );
+  }
+
+  Widget recordCarouselSlider(List<Widget> recordList) {
+    return CarouselSlider(
+      items: recordList,
+      options: CarouselOptions(
+        height: MediaQuery.of(context).size.height * 0.55,
+        initialPage: 0,
+        autoPlay: false,
+        viewportFraction: 1,
+        enableInfiniteScroll: true,
+        onPageChanged: ((index, reason) {
+          setState(() {
+            currentIndex = index;
+          });
+        }),
+      ),
+    );
+  }
+
+  Widget dotIndicator(List<Widget> recordList) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: recordList.map((url) {
+        int index = recordList.indexOf(url);
+        return Container(
+          width: 8.0,
+          height: 8.0,
+          margin: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 2.0),
+          decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color:
+                  currentIndex == index ? Colors.grey[800] : Colors.grey[500]),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
@@ -9,11 +9,11 @@ class DailyPage extends StatefulWidget {
 }
 
 class _DailyPageState extends State<DailyPage> {
+  var isBoarding = false;
   var hasBag = true;
   var hasLunchBox = true;
   var hasWaterBottle = true;
-  var hasUmbrella = true;
-  var isBoarding = true;
+  var hasUmbrella = false;
 
   @override
   Widget build(BuildContext context) {
@@ -37,8 +37,10 @@ class _DailyPageState extends State<DailyPage> {
       children: <Widget>[
         childFaceAndExpression(),
         Padding(
-            padding: const EdgeInsets.only(top: 20, bottom: 20),
+            padding: const EdgeInsets.only(top: 20, bottom: 10),
             child: childName()),
+        statusIconAndStatusField(
+            Icons.directions_bus, isBoardingStatusField(context)),
         statusIconAndStatusField(Icons.business_center, childItemList(context)),
       ],
     );
@@ -99,13 +101,35 @@ class _DailyPageState extends State<DailyPage> {
         ));
   }
 
+  Widget isBoardingStatusField(context) {
+    return Container(
+      width: MediaQuery.of(context).size.width * 0.5,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(5),
+        border: Border.all(
+          color: isBoarding ? Colors.red : Colors.green,
+        ),
+        color: isBoarding ? Colors.red[100] : Colors.green[100],
+      ),
+      child: Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Text(
+            isBoarding ? "乗車中" : "降車済",
+            style: TextStyle(
+              fontSize: 16,
+              color: isBoarding ? Colors.red : Colors.green,
+            ),
+            textAlign: TextAlign.center,
+          )),
+    );
+  }
+
   Widget childItemList(BuildContext context) {
     return SizedBox(
-      width: MediaQuery.of(context).size.width * 0.6,
+      width: MediaQuery.of(context).size.width * 0.5,
       child: Wrap(
         direction: Axis.horizontal,
-        alignment: WrapAlignment.center,
-        spacing: 8.0,
+        alignment: WrapAlignment.spaceBetween,
         runAlignment: WrapAlignment.spaceBetween,
         runSpacing: 4.0,
         children: [
@@ -120,7 +144,7 @@ class _DailyPageState extends State<DailyPage> {
 
   Widget itemText(String itemName, bool hasItem) {
     return Container(
-        width: 90,
+        width: MediaQuery.of(context).size.width * 0.24,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(5),
           border: Border.all(
@@ -129,7 +153,7 @@ class _DailyPageState extends State<DailyPage> {
           color: hasItem ? Colors.green[100] : Colors.red[100],
         ),
         child: Padding(
-          padding: const EdgeInsets.all(10.0),
+          padding: const EdgeInsets.only(top: 10.0, bottom: 10.0),
           child: Text(
             itemName,
             style: TextStyle(

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:where_child_bus_guardian/components/utils/current_time_body.dart';
+import 'package:where_child_bus_guardian/pages/daily_page/components/daily_record_body.dart';
 
 class DailyPage extends StatefulWidget {
   const DailyPage({super.key});
@@ -11,13 +12,7 @@ class DailyPage extends StatefulWidget {
 
 class _DailyPageState extends State<DailyPage> {
   //TODO: 将来的にChild型を受け取る
-  final List<String> childNames = ["園児1", "園児2", "園児3"];
-
-  var isBoarding = true;
-  var hasBag = false;
-  var hasLunchBox = true;
-  var hasWaterBottle = true;
-  var hasUmbrella = true;
+  final List<String> childNames = ["園児1", "園児2"];
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +33,7 @@ class _DailyPageState extends State<DailyPage> {
 
   Widget childDailyRecordSlider(BuildContext context) {
     List<Widget> recordList = childNames.map((name) {
-      return childDailyRecordBody(context, name);
+      return DailyRecordBody(childName: name);
     }).toList();
     return CarouselSlider(
       items: recordList,
@@ -49,137 +44,6 @@ class _DailyPageState extends State<DailyPage> {
         viewportFraction: 1,
         enableInfiniteScroll: true,
       ),
-    );
-  }
-
-  Widget childDailyRecordBody(BuildContext context, String name) {
-    return Column(
-      children: <Widget>[
-        childFaceAndExpression(),
-        Padding(
-            padding: const EdgeInsets.only(top: 20, bottom: 10),
-            child: childName(name)),
-        statusIconAndStatusField(
-            Icons.directions_bus, isBoardingStatusField(context)),
-        statusIconAndStatusField(Icons.business_center, childItemList(context)),
-      ],
-    );
-  }
-
-  Widget childFaceAndExpression() {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceAround,
-      children: <Widget>[childFaceImage(), childExpressionIcon()],
-    );
-  }
-
-  //TODO: 将来的に画像を受け取る
-  Widget childFaceImage() {
-    return const SizedBox(
-      width: 150,
-      height: 150,
-      child: Card(
-        color: Colors.grey,
-        child: Text("ここに子供の写真が入る"),
-      ),
-    );
-  }
-
-  //TODO: 将来的に表情を受け取り、アイコンを表示する
-  Widget childExpressionIcon() {
-    return const SizedBox(
-      width: 100,
-      height: 100,
-      child: Card(
-        color: Colors.grey,
-        child: Text("ここに表情のアイコンが入る"),
-      ),
-    );
-  }
-
-  Widget childName(String name) {
-    return Text(
-      name,
-      style: TextStyle(fontSize: 24),
-      textAlign: TextAlign.center,
-    );
-  }
-
-  Widget statusIconAndStatusField(IconData icon, Widget statusField) {
-    return SizedBox(
-        width: MediaQuery.of(context).size.width * 0.9,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children: <Widget>[
-            Icon(
-              icon,
-              size: 80,
-            ),
-            statusField,
-          ],
-        ));
-  }
-
-  Widget isBoardingStatusField(context) {
-    return Container(
-      width: MediaQuery.of(context).size.width * 0.5,
-      decoration: statusFieldDecoration(!isBoarding),
-      child: Padding(
-          padding: const EdgeInsets.all(10.0),
-          child: Text(
-            isBoarding ? "乗車中" : "降車済",
-            style: statusFieldTextStyle(!isBoarding),
-            textAlign: TextAlign.center,
-          )),
-    );
-  }
-
-  Widget childItemList(BuildContext context) {
-    return SizedBox(
-      width: MediaQuery.of(context).size.width * 0.5,
-      child: Wrap(
-        direction: Axis.horizontal,
-        alignment: WrapAlignment.spaceBetween,
-        runAlignment: WrapAlignment.spaceBetween,
-        runSpacing: 4.0,
-        children: [
-          itemText("かばん", hasBag),
-          itemText("お弁当", hasLunchBox),
-          itemText("水筒", hasWaterBottle),
-          itemText("傘", hasUmbrella),
-        ],
-      ),
-    );
-  }
-
-  Widget itemText(String itemName, bool hasItem) {
-    return Container(
-        width: MediaQuery.of(context).size.width * 0.24,
-        decoration: statusFieldDecoration(hasItem),
-        child: Padding(
-          padding: const EdgeInsets.only(top: 10.0, bottom: 10.0),
-          child: Text(
-            itemName,
-            style: statusFieldTextStyle(hasItem),
-            textAlign: TextAlign.center,
-          ),
-        ));
-  }
-
-  BoxDecoration statusFieldDecoration(bool isTrue) {
-    return BoxDecoration(
-      borderRadius: BorderRadius.circular(5),
-      border: Border.all(
-        color: isTrue ? Colors.green : Colors.red,
-      ),
-      color: isTrue ? Colors.green[100] : Colors.red[100],
-    );
-  }
-
-  TextStyle statusFieldTextStyle(bool isTrue) {
-    return TextStyle(
-      fontSize: 16,
-      color: isTrue ? Colors.green : Colors.red,
     );
   }
 }

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
@@ -9,32 +9,38 @@ class DailyPage extends StatefulWidget {
 }
 
 class _DailyPageState extends State<DailyPage> {
+  var hasBag = true;
+  var hasLunchBox = true;
+  var hasWaterBottle = true;
+  var hasUmbrella = true;
+  var isBoarding = true;
+
   @override
   Widget build(BuildContext context) {
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
           CurrentTimeBody(),
           const SizedBox(
             height: 20,
           ),
-          childDailyRecordBody()
+          childDailyRecordBody(context)
         ],
       ),
     );
   }
 
-  Widget childDailyRecordBody() {
-    return Container(
-      child: Column(
-        children: <Widget>[
-          childFaceAndExpression(),
-          Padding(
-              padding: EdgeInsets.only(top: 20, bottom: 20),
-              child: childName()),
-        ],
-      ),
+  Widget childDailyRecordBody(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        childFaceAndExpression(),
+        Padding(
+            padding: const EdgeInsets.only(top: 20, bottom: 20),
+            child: childName()),
+        statusIconAndStatusField(Icons.business_center, childItemList(context)),
+      ],
     );
   }
 
@@ -76,5 +82,62 @@ class _DailyPageState extends State<DailyPage> {
       style: TextStyle(fontSize: 24),
       textAlign: TextAlign.center,
     );
+  }
+
+  Widget statusIconAndStatusField(IconData icon, Widget statusField) {
+    return SizedBox(
+        width: MediaQuery.of(context).size.width * 0.9,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: <Widget>[
+            Icon(
+              icon,
+              size: 80,
+            ),
+            statusField,
+          ],
+        ));
+  }
+
+  Widget childItemList(BuildContext context) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width * 0.6,
+      child: Wrap(
+        direction: Axis.horizontal,
+        alignment: WrapAlignment.center,
+        spacing: 8.0,
+        runAlignment: WrapAlignment.spaceBetween,
+        runSpacing: 4.0,
+        children: [
+          itemText("かばん", hasBag),
+          itemText("お弁当", hasLunchBox),
+          itemText("水筒", hasWaterBottle),
+          itemText("傘", hasUmbrella),
+        ],
+      ),
+    );
+  }
+
+  Widget itemText(String itemName, bool hasItem) {
+    return Container(
+        width: 90,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(5),
+          border: Border.all(
+            color: hasItem ? Colors.green : Colors.red,
+          ),
+          color: hasItem ? Colors.green[100] : Colors.red[100],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Text(
+            itemName,
+            style: TextStyle(
+              fontSize: 16,
+              color: hasItem ? Colors.green : Colors.red,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ));
   }
 }

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
@@ -17,10 +17,64 @@ class _DailyPageState extends State<DailyPage> {
         children: <Widget>[
           CurrentTimeBody(),
           const SizedBox(
-            height: 50,
+            height: 20,
           ),
+          childDailyRecordBody()
         ],
       ),
+    );
+  }
+
+  Widget childDailyRecordBody() {
+    return Container(
+      child: Column(
+        children: <Widget>[
+          childFaceAndExpression(),
+          Padding(
+              padding: EdgeInsets.only(top: 20, bottom: 20),
+              child: childName()),
+        ],
+      ),
+    );
+  }
+
+  Widget childFaceAndExpression() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: <Widget>[childFaceImage(), childExpressionIcon()],
+    );
+  }
+
+  //TODO: 将来的に画像を受け取る
+  Widget childFaceImage() {
+    return const SizedBox(
+      width: 150,
+      height: 150,
+      child: Card(
+        color: Colors.grey,
+        child: Text("ここに子供の写真が入る"),
+      ),
+    );
+  }
+
+  //TODO: 将来的に表情を受け取る
+  Widget childExpressionIcon() {
+    return const SizedBox(
+      width: 100,
+      height: 100,
+      child: Card(
+        color: Colors.grey,
+        child: Text("ここに表情のアイコンが入る"),
+      ),
+    );
+  }
+
+  //将来的に名前を受け取る
+  Widget childName() {
+    return const Text(
+      "園児1",
+      style: TextStyle(fontSize: 24),
+      textAlign: TextAlign.center,
     );
   }
 }

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:carousel_slider/carousel_slider.dart';
 import 'package:where_child_bus_guardian/components/utils/current_time_body.dart';
 
 class DailyPage extends StatefulWidget {
@@ -9,7 +10,9 @@ class DailyPage extends StatefulWidget {
 }
 
 class _DailyPageState extends State<DailyPage> {
-  //TODO: 将来的に真偽値を受け取る
+  //TODO: 将来的にChild型を受け取る
+  final List<String> childNames = ["園児1", "園児2", "園児3"];
+
   var isBoarding = true;
   var hasBag = false;
   var hasLunchBox = true;
@@ -27,19 +30,35 @@ class _DailyPageState extends State<DailyPage> {
           const SizedBox(
             height: 20,
           ),
-          childDailyRecordBody(context)
+          childDailyRecordSlider(context)
         ],
       ),
     );
   }
 
-  Widget childDailyRecordBody(BuildContext context) {
+  Widget childDailyRecordSlider(BuildContext context) {
+    List<Widget> recordList = childNames.map((name) {
+      return childDailyRecordBody(context, name);
+    }).toList();
+    return CarouselSlider(
+      items: recordList,
+      options: CarouselOptions(
+        height: MediaQuery.of(context).size.height * 0.6,
+        initialPage: 0,
+        autoPlay: false,
+        viewportFraction: 1,
+        enableInfiniteScroll: true,
+      ),
+    );
+  }
+
+  Widget childDailyRecordBody(BuildContext context, String name) {
     return Column(
       children: <Widget>[
         childFaceAndExpression(),
         Padding(
             padding: const EdgeInsets.only(top: 20, bottom: 10),
-            child: childName()),
+            child: childName(name)),
         statusIconAndStatusField(
             Icons.directions_bus, isBoardingStatusField(context)),
         statusIconAndStatusField(Icons.business_center, childItemList(context)),
@@ -78,10 +97,9 @@ class _DailyPageState extends State<DailyPage> {
     );
   }
 
-  //TODO: 将来的に名前を受け取る
-  Widget childName() {
-    return const Text(
-      "園児1",
+  Widget childName(String name) {
+    return Text(
+      name,
       style: TextStyle(fontSize: 24),
       textAlign: TextAlign.center,
     );
@@ -105,21 +123,12 @@ class _DailyPageState extends State<DailyPage> {
   Widget isBoardingStatusField(context) {
     return Container(
       width: MediaQuery.of(context).size.width * 0.5,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(5),
-        border: Border.all(
-          color: isBoarding ? Colors.red : Colors.green,
-        ),
-        color: isBoarding ? Colors.red[100] : Colors.green[100],
-      ),
+      decoration: statusFieldDecoration(!isBoarding),
       child: Padding(
           padding: const EdgeInsets.all(10.0),
           child: Text(
             isBoarding ? "乗車中" : "降車済",
-            style: TextStyle(
-              fontSize: 16,
-              color: isBoarding ? Colors.red : Colors.green,
-            ),
+            style: statusFieldTextStyle(!isBoarding),
             textAlign: TextAlign.center,
           )),
     );
@@ -146,23 +155,31 @@ class _DailyPageState extends State<DailyPage> {
   Widget itemText(String itemName, bool hasItem) {
     return Container(
         width: MediaQuery.of(context).size.width * 0.24,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(5),
-          border: Border.all(
-            color: hasItem ? Colors.green : Colors.red,
-          ),
-          color: hasItem ? Colors.green[100] : Colors.red[100],
-        ),
+        decoration: statusFieldDecoration(hasItem),
         child: Padding(
           padding: const EdgeInsets.only(top: 10.0, bottom: 10.0),
           child: Text(
             itemName,
-            style: TextStyle(
-              fontSize: 16,
-              color: hasItem ? Colors.green : Colors.red,
-            ),
+            style: statusFieldTextStyle(hasItem),
             textAlign: TextAlign.center,
           ),
         ));
+  }
+
+  BoxDecoration statusFieldDecoration(bool isTrue) {
+    return BoxDecoration(
+      borderRadius: BorderRadius.circular(5),
+      border: Border.all(
+        color: isTrue ? Colors.green : Colors.red,
+      ),
+      color: isTrue ? Colors.green[100] : Colors.red[100],
+    );
+  }
+
+  TextStyle statusFieldTextStyle(bool isTrue) {
+    return TextStyle(
+      fontSize: 16,
+      color: isTrue ? Colors.green : Colors.red,
+    );
   }
 }

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
@@ -9,11 +9,12 @@ class DailyPage extends StatefulWidget {
 }
 
 class _DailyPageState extends State<DailyPage> {
-  var isBoarding = false;
-  var hasBag = true;
+  //TODO: 将来的に真偽値を受け取る
+  var isBoarding = true;
+  var hasBag = false;
   var hasLunchBox = true;
   var hasWaterBottle = true;
-  var hasUmbrella = false;
+  var hasUmbrella = true;
 
   @override
   Widget build(BuildContext context) {
@@ -65,7 +66,7 @@ class _DailyPageState extends State<DailyPage> {
     );
   }
 
-  //TODO: 将来的に表情を受け取る
+  //TODO: 将来的に表情を受け取り、アイコンを表示する
   Widget childExpressionIcon() {
     return const SizedBox(
       width: 100,
@@ -77,7 +78,7 @@ class _DailyPageState extends State<DailyPage> {
     );
   }
 
-  //将来的に名前を受け取る
+  //TODO: 将来的に名前を受け取る
   Widget childName() {
     return const Text(
       "園児1",

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:carousel_slider/carousel_slider.dart';
 import 'package:where_child_bus_guardian/components/utils/current_time_body.dart';
-import 'package:where_child_bus_guardian/pages/daily_page/components/daily_record_body.dart';
+import 'package:where_child_bus_guardian/pages/daily_page/components/daily_record_slider.dart';
 
 class DailyPage extends StatefulWidget {
   const DailyPage({super.key});
@@ -12,7 +11,7 @@ class DailyPage extends StatefulWidget {
 
 class _DailyPageState extends State<DailyPage> {
   //TODO: 将来的にChild型を受け取る
-  final List<String> childNames = ["園児1", "園児2"];
+  final List<String> childNames = ["園児1", "園児2", "園児3"];
 
   @override
   Widget build(BuildContext context) {
@@ -25,24 +24,8 @@ class _DailyPageState extends State<DailyPage> {
           const SizedBox(
             height: 20,
           ),
-          childDailyRecordSlider(context)
+          DailyRecordSlider(childNames: childNames),
         ],
-      ),
-    );
-  }
-
-  Widget childDailyRecordSlider(BuildContext context) {
-    List<Widget> recordList = childNames.map((name) {
-      return DailyRecordBody(childName: name);
-    }).toList();
-    return CarouselSlider(
-      items: recordList,
-      options: CarouselOptions(
-        height: MediaQuery.of(context).size.height * 0.6,
-        initialPage: 0,
-        autoPlay: false,
-        viewportFraction: 1,
-        enableInfiniteScroll: true,
       ),
     );
   }

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/daily_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:where_child_bus_guardian/components/utils/current_time_body.dart';
 
 class DailyPage extends StatefulWidget {
   const DailyPage({super.key});
@@ -10,12 +11,13 @@ class DailyPage extends StatefulWidget {
 class _DailyPageState extends State<DailyPage> {
   @override
   Widget build(BuildContext context) {
-    return const Center(
+    return Center(
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
-          Text(
-            '日々の記録',
+          CurrentTimeBody(),
+          const SizedBox(
+            height: 50,
           ),
         ],
       ),

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/styles/styles.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/styles/styles.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+BoxDecoration statusFieldDecoration(bool isTrue) {
+  return BoxDecoration(
+    borderRadius: BorderRadius.circular(5),
+    border: Border.all(
+      color: isTrue ? Colors.green : Colors.red,
+    ),
+    color: isTrue ? Colors.green[100] : Colors.red[100],
+  );
+}
+
+TextStyle statusFieldTextStyle(bool isTrue) {
+  return TextStyle(
+    fontSize: 16,
+    color: isTrue ? Colors.green : Colors.red,
+  );
+}

--- a/frontend/where_child_bus_guardian/lib/pages/daily_page/styles/styles.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/daily_page/styles/styles.dart
@@ -13,6 +13,6 @@ BoxDecoration statusFieldDecoration(bool isTrue) {
 TextStyle statusFieldTextStyle(bool isTrue) {
   return TextStyle(
     fontSize: 16,
-    color: isTrue ? Colors.green : Colors.red,
+    color: isTrue ? Colors.green[900] : Colors.red[900],
   );
 }

--- a/frontend/where_child_bus_guardian/pubspec.lock
+++ b/frontend/where_child_bus_guardian/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  carousel_slider:
+    dependency: "direct main"
+    description:
+      name: carousel_slider
+      sha256: "9c695cc963bf1d04a47bd6021f68befce8970bcd61d24938e1fb0918cf5d9c42"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.1"
   characters:
     dependency: transitive
     description:

--- a/frontend/where_child_bus_guardian/pubspec.lock
+++ b/frontend/where_child_bus_guardian/pubspec.lock
@@ -126,6 +126,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  flutter_state_notifier:
+    dependency: "direct main"
+    description:
+      name: flutter_state_notifier
+      sha256: bd8d4eabd4b74f11733409305369c112fa2f7989290f73ee75ae2cbfcf04b8a3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -219,6 +227,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -243,6 +259,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: "9a96a0a19b594dbc5bf0f1f27d2bc67d5f95957359b461cd9feb44ed6ae75096"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -264,6 +288,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/frontend/where_child_bus_guardian/pubspec.yaml
+++ b/frontend/where_child_bus_guardian/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
 
   cupertino_icons: ^1.0.2
   flutter_toggle_tab: ^1.4.1
+  carousel_slider: ^4.2.1
 
 dev_dependencies:
   flutter_test:

--- a/frontend/where_child_bus_guardian/pubspec.yaml
+++ b/frontend/where_child_bus_guardian/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter_toggle_tab: ^1.4.1
   carousel_slider: ^4.2.1
+  flutter_state_notifier: ^1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## チケットへのリンク

- 無し

## やったこと

- 保護者アプリのデイリービューの画面を実装しました。

## やらないこと

- バックエンドとの通信は別ブランチで行う。

## できるようになること（ユーザ目線）

- 保護者が園児の記録を確認できるようになる。

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- Androidエミュレータにて動作確認済み

## その他

- 無し
