### PR TITLE
feat:保護者一覧選択画面を実装

### DIFF
--- a/frontend/where_child_bus/lib/components/guardian_list/guardian_list.dart
+++ b/frontend/where_child_bus/lib/components/guardian_list/guardian_list.dart
@@ -1,0 +1,39 @@
+
+import 'package:flutter/material.dart';
+import 'package:where_child_bus/components/guardian_list/guardian_list_element/guardian_list_element.dart';
+import 'package:where_child_bus/pages/student_list_page/student_detail_sheet.dart';
+
+class GuardianList extends StatefulWidget {
+  final List<String> guardianNames;
+  final List<String> groupNames;
+  final VoidCallback? callback;
+
+  const GuardianList({
+    Key? key,
+    required this.guardianNames,
+    required this.groupNames,
+    this.callback,
+  }) : super(key: key);
+
+  @override
+  _GuardiansListState createState() => _GuardiansListState();
+}
+
+class _GuardiansListState extends State<GuardianList> {
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      itemCount: widget.guardianNames.length,
+      separatorBuilder: (BuildContext context, int index) => const Divider(height: 20, color: Colors.transparent),
+      itemBuilder: (BuildContext context, int index) => guardianListElement(context, index),
+    );
+  }
+
+  Widget guardianListElement(BuildContext context, int index) {
+    return GuardianListElement(
+      title: widget.guardianNames[index],
+      subtitle: widget.groupNames[index],
+      // imagePath: "assets/images/face_${widget.images[index]}.png",
+    );
+  }
+}

--- a/frontend/where_child_bus/lib/components/guardian_list/guardian_list.dart
+++ b/frontend/where_child_bus/lib/components/guardian_list/guardian_list.dart
@@ -31,6 +31,7 @@ class _GuardiansListState extends State<GuardianList> {
     return Column(
       children: [
         addedGuardiansListView(),
+        const SizedBox(height: 15,),
         unSelectedGuardiansListView(),
       ],
     );
@@ -53,7 +54,7 @@ Widget addedGuardiansListView() {
   double screenHeight = MediaQuery.of(context).size.height;
   double maxHeight = screenHeight * 0.5;
 
-  double itemHeight = 100.0;
+  double itemHeight = 110.0;
   double actualHeight = widget.addedGuardians.length * itemHeight;
 
   double listViewHeight = actualHeight > maxHeight ? maxHeight : actualHeight;
@@ -76,11 +77,9 @@ Widget addedGuardiansListView() {
         return SelectedGuardianListElement(
           key: ValueKey(item), // 一意のキーを指定
           title: item, // 保護者の名前
-          subtitle: "サブタイトル $index", // サブタイトル（適宜変更可能）
+          subtitle: "サブタイトル",
           order: index + 1, // 順序番号（1から始まるように+1をしている）
-          onButtonPressed: () {
-            // ボタンが押された時のアクション（必要に応じて実装）
-          },
+          onButtonPressed: () => removeGuardians(index),
         );
       }).toList(),
     ),
@@ -95,9 +94,7 @@ Widget addedGuardiansListView() {
       onButtonPressed: () => addGuardians(index),
     );
   }
-
   
-  //functions
   void addGuardians(int index) {
     setState(() {
       widget.addedGuardians.add(widget.guardianNames[index]);
@@ -106,9 +103,17 @@ Widget addedGuardiansListView() {
     });
   }
 
-  void swap(List list, int index1, int index2) {
-    var temp = list[index1];
-    list[index1] = list[index2];
-    list[index2] = temp;
-  }
+  void removeGuardians(int index) {
+  setState(() {
+    // 追加された保護者リストから保護者を取得し削除
+    String removedGuardian = widget.addedGuardians.removeAt(index);
+
+    //戻すときは、先頭に配置
+    widget.guardianNames.insert(0, removedGuardian);
+    
+    // groupNamesへの追加も必要ですが、どのグループに所属していたかの情報が必要
+    widget.groupNames.add("ダミーグループ");
+  });
+}
+
 }

--- a/frontend/where_child_bus/lib/components/guardian_list/guardian_list.dart
+++ b/frontend/where_child_bus/lib/components/guardian_list/guardian_list.dart
@@ -28,12 +28,66 @@ class _GuardiansListState extends State<GuardianList> {
   }
 
   Widget body() {
-    return Column(
-      children: [
-        addedGuardiansListView(),
-        const SizedBox(height: 15,),
-        unSelectedGuardiansListView(),
-      ],
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          Container(
+            height: calculateAddedGuardiansHeight(),
+            child: ReorderableListView(
+              onReorder: (int oldIndex, int newIndex) => onReorder(oldIndex, newIndex),
+              shrinkWrap: true,
+              physics: NeverScrollableScrollPhysics(),
+              children: widget.addedGuardians.map((item) {
+                int index = widget.addedGuardians.indexOf(item);
+                return SelectedGuardianListElement(
+                  key: ValueKey(item),
+                  title: item,
+                  subtitle: "サブタイトル ${index + 1}",
+                  order: index + 1,
+                  onButtonPressed: () => removeGuardians(index),
+                );
+              }).toList(),
+            ),
+          ),
+          const SizedBox(height: 15),
+          for (int index = 0; index < widget.guardianNames.length; index++)
+            guardianListElement(context, index),
+        ],
+      ),
+    );
+  }
+
+  void onReorder(int oldIndex, int newIndex) {
+    setState(() {
+      if (newIndex > oldIndex) {
+        newIndex -= 1;
+      }
+      final item = widget.addedGuardians.removeAt(oldIndex);
+      widget.addedGuardians.insert(newIndex, item);
+    });
+  }
+
+
+  double calculateAddedGuardiansHeight() {
+    // 項目の高さ、項目間のスペース、その他のマージンなどを考慮して高さを計算
+    double itemHeight = 110.0; 
+    int itemCount = widget.addedGuardians.length;
+    return itemHeight * itemCount; 
+  }
+
+  Widget addedGuardiansListViewContent() {
+    return ListView.builder(
+      itemCount: widget.addedGuardians.length,
+      itemBuilder: (context, index) {
+        String item = widget.addedGuardians[index];
+        // 追加された保護者リストの項目を構築
+        return SelectedGuardianListElement(
+          title: item,
+          subtitle: "サブタイトル",
+          order: index + 1,
+          onButtonPressed: () => removeGuardians(index),
+        );
+      },
     );
   }
 

--- a/frontend/where_child_bus/lib/components/guardian_list/guardian_list.dart
+++ b/frontend/where_child_bus/lib/components/guardian_list/guardian_list.dart
@@ -1,17 +1,18 @@
-
 import 'package:flutter/material.dart';
 import 'package:where_child_bus/components/guardian_list/guardian_list_element/guardian_list_element.dart';
-import 'package:where_child_bus/pages/student_list_page/student_detail_sheet.dart';
+import 'package:where_child_bus/components/guardian_list/guardian_list_element/selected_guardian_list_element.dart';
 
 class GuardianList extends StatefulWidget {
   final List<String> guardianNames;
   final List<String> groupNames;
+  final List<String> addedGuardians;
   final VoidCallback? callback;
 
   const GuardianList({
     Key? key,
     required this.guardianNames,
     required this.groupNames,
+    required this.addedGuardians,
     this.callback,
   }) : super(key: key);
 
@@ -20,20 +21,94 @@ class GuardianList extends StatefulWidget {
 }
 
 class _GuardiansListState extends State<GuardianList> {
+
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      itemCount: widget.guardianNames.length,
-      separatorBuilder: (BuildContext context, int index) => const Divider(height: 20, color: Colors.transparent),
-      itemBuilder: (BuildContext context, int index) => guardianListElement(context, index),
+    return body();
+  }
+
+  Widget body() {
+    return Column(
+      children: [
+        addedGuardiansListView(),
+        unSelectedGuardiansListView(),
+      ],
     );
   }
+
+  Widget unSelectedGuardiansListView() {
+    return Expanded(
+      child: ListView.separated(
+        itemCount: widget.guardianNames.length,
+        separatorBuilder: (BuildContext context, int index) => const Divider(height: 20, color: Colors.transparent),
+        itemBuilder: (BuildContext context, int index) {
+          // orderIndexesに基づいて項目を表示
+          return guardianListElement(context, index);
+        },
+      ),
+    );
+  }
+
+Widget addedGuardiansListView() {
+  double screenHeight = MediaQuery.of(context).size.height;
+  double maxHeight = screenHeight * 0.5;
+
+  double itemHeight = 100.0;
+  double actualHeight = widget.addedGuardians.length * itemHeight;
+
+  double listViewHeight = actualHeight > maxHeight ? maxHeight : actualHeight;
+
+  return SizedBox(
+    height: listViewHeight, // ReorderableListViewの高さを100に設定
+    child: ReorderableListView(
+      onReorder: (int oldIndex, int newIndex) {
+        setState(() {
+          if (newIndex > oldIndex) {
+            newIndex -= 1;
+          }
+          final item = widget.addedGuardians.removeAt(oldIndex);
+          widget.addedGuardians.insert(newIndex, item);
+        });
+      },
+      children: widget.addedGuardians.asMap().entries.map((entry) {
+        int index = entry.key;
+        String item = entry.value;
+        return SelectedGuardianListElement(
+          key: ValueKey(item), // 一意のキーを指定
+          title: item, // 保護者の名前
+          subtitle: "サブタイトル $index", // サブタイトル（適宜変更可能）
+          order: index + 1, // 順序番号（1から始まるように+1をしている）
+          onButtonPressed: () {
+            // ボタンが押された時のアクション（必要に応じて実装）
+          },
+        );
+      }).toList(),
+    ),
+  );
+}
+
 
   Widget guardianListElement(BuildContext context, int index) {
     return GuardianListElement(
       title: widget.guardianNames[index],
       subtitle: widget.groupNames[index],
-      // imagePath: "assets/images/face_${widget.images[index]}.png",
+      onButtonPressed: () => addGuardians(index),
     );
+  }
+
+  
+  //functions
+  void addGuardians(int index) {
+    setState(() {
+      widget.addedGuardians.add(widget.guardianNames[index]);
+      widget.groupNames.removeAt(index);
+      widget.guardianNames.removeAt(index);
+    });
+  }
+
+  void swap(List list, int index1, int index2) {
+    var temp = list[index1];
+    list[index1] = list[index2];
+    list[index2] = temp;
   }
 }

--- a/frontend/where_child_bus/lib/components/guardian_list/guardian_list_element/guardian_list_element.dart
+++ b/frontend/where_child_bus/lib/components/guardian_list/guardian_list_element/guardian_list_element.dart
@@ -1,0 +1,75 @@
+
+import 'package:flutter/material.dart';
+
+class GuardianListElement extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final VoidCallback? onTap;
+  final Widget? actionButton; 
+
+  const GuardianListElement({
+    Key? key,
+    required this.title,
+    required this.subtitle,
+    this.onTap,
+    this.actionButton, 
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return listElementPadding(
+      Card(
+        elevation: 8,
+        clipBehavior: Clip.antiAliasWithSaveLayer,
+        child: Material(
+          color: Colors.white, // Cardの背景色
+          child: InkWell(
+            onTap: onTap, // タップ時のアクション
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                children: [
+                  // Image.asset(imagePath, width: 100, height: 100),
+                  // const SizedBox(width: 16),
+                  Expanded(
+                    child: titleAndSubTitle(title, subtitle),
+                  ),
+                  if (actionButton != null) actionButton!, // アクションボタンを表示
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Column titleAndSubTitle(String title, String subtitle) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        titleText(title),
+        subTitleText(subtitle),
+      ],
+    );
+  }
+
+  Text titleText(String title) {
+    return Text(
+      title,
+      style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)
+    );
+  }
+
+  Text subTitleText(String subtitle) {
+    return Text(subtitle);
+  }
+
+  Padding listElementPadding(Widget child) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: child,
+    );
+  }
+}

--- a/frontend/where_child_bus/lib/components/guardian_list/guardian_list_element/guardian_list_element.dart
+++ b/frontend/where_child_bus/lib/components/guardian_list/guardian_list_element/guardian_list_element.dart
@@ -1,20 +1,23 @@
-
 import 'package:flutter/material.dart';
+import 'package:where_child_bus/components/util/number_icon.dart';
 
-class GuardianListElement extends StatelessWidget {
+class GuardianListElement extends StatefulWidget {
   final String title;
   final String subtitle;
-  final VoidCallback? onTap;
-  final Widget? actionButton; 
+  final VoidCallback? onButtonPressed;
 
   const GuardianListElement({
     Key? key,
     required this.title,
     required this.subtitle,
-    this.onTap,
-    this.actionButton, 
+    this.onButtonPressed,
   }) : super(key: key);
 
+  @override
+  _GuardianListElementState createState() => _GuardianListElementState();
+}
+
+class _GuardianListElementState extends State<GuardianListElement> {
   @override
   Widget build(BuildContext context) {
     return listElementPadding(
@@ -23,20 +26,13 @@ class GuardianListElement extends StatelessWidget {
         clipBehavior: Clip.antiAliasWithSaveLayer,
         child: Material(
           color: Colors.white, // Cardの背景色
-          child: InkWell(
-            onTap: onTap, // タップ時のアクション
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Row(
-                children: [
-                  // Image.asset(imagePath, width: 100, height: 100),
-                  // const SizedBox(width: 16),
-                  Expanded(
-                    child: titleAndSubTitle(title, subtitle),
-                  ),
-                  if (actionButton != null) actionButton!, // アクションボタンを表示
-                ],
-              ),
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                titleAndSubTitle(widget.title, widget.subtitle),
+                addButton(),
+              ],
             ),
           ),
         ),
@@ -44,21 +40,34 @@ class GuardianListElement extends StatelessWidget {
     );
   }
 
-  Column titleAndSubTitle(String title, String subtitle) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        titleText(title),
-        subTitleText(subtitle),
-      ],
+  Widget addButton() {
+    return IconButton(
+      onPressed: widget.onButtonPressed,
+      icon: const Icon(Icons.add),
+    );
+  }
+
+  Widget orderIcon(int number) {
+    return NumberIcon(number: number);
+  }
+
+  Widget titleAndSubTitle(String title, String subtitle) {
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          titleText(title),
+          subTitleText(subtitle),
+        ],
+      ),
     );
   }
 
   Text titleText(String title) {
     return Text(
       title,
-      style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)
+      style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
     );
   }
 

--- a/frontend/where_child_bus/lib/components/guardian_list/guardian_list_element/selected_guardian_list_element.dart
+++ b/frontend/where_child_bus/lib/components/guardian_list/guardian_list_element/selected_guardian_list_element.dart
@@ -30,7 +30,7 @@ class _SelectedGuardianListElementState extends State<SelectedGuardianListElemen
         child: InkWell(
           onTap: widget.onButtonPressed,
           child: Padding(
-            padding: const EdgeInsets.all(16.0),
+            padding: const EdgeInsets.symmetric(horizontal:8.0, vertical: 16),
             child: Row(
               children: [
                 // 並び替え用のドラッグハンドルアイコンを追加
@@ -42,8 +42,9 @@ class _SelectedGuardianListElementState extends State<SelectedGuardianListElemen
                   ),
                 ),
                 NumberIcon(number: widget.order, color: Colors.indigo,), // 順序番号アイコン
-                SizedBox(width: 16),
-                titleText(widget.title,),
+                const SizedBox(width: 16),
+                Expanded(child: titleAndSubTitle(widget.title, widget.subtitle)),
+                removeButton(),
               ],
             ),
           ),
@@ -51,11 +52,24 @@ class _SelectedGuardianListElementState extends State<SelectedGuardianListElemen
       ),
     );
   }
-  Widget addButton() {
-    // ボタンの表示をカスタマイズする場合はここで変更
+
+  Widget removeButton() {
     return IconButton(
       onPressed: widget.onButtonPressed,
-      icon: const Icon(Icons.add),
+      icon: const Icon(Icons.remove),
+    );
+  }
+
+  Widget titleAndSubTitle(String title, String subtitle) {
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          titleText(title),
+          subTitleText(subtitle),
+        ],
+      ),
     );
   }
 
@@ -64,6 +78,10 @@ class _SelectedGuardianListElementState extends State<SelectedGuardianListElemen
       title,
       style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
     );
+  }
+
+  Text subTitleText(String subtitle) {
+    return Text(subtitle);
   }
 
   Padding listElementPadding(Widget child) {

--- a/frontend/where_child_bus/lib/components/guardian_list/guardian_list_element/selected_guardian_list_element.dart
+++ b/frontend/where_child_bus/lib/components/guardian_list/guardian_list_element/selected_guardian_list_element.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:where_child_bus/components/util/number_icon.dart';
+
+class SelectedGuardianListElement extends StatefulWidget {
+  final String title;
+  final String subtitle;
+  final int order; // 追加: リスト内の順序を表示するための順序番号
+  final VoidCallback? onButtonPressed;
+
+  const SelectedGuardianListElement({
+    Key? key,
+    required this.title,
+    required this.subtitle,
+    required this.order, // 順序番号を必須引数として追加
+    this.onButtonPressed,
+  }) : super(key: key);
+
+  @override
+  _SelectedGuardianListElementState createState() => _SelectedGuardianListElementState();
+}
+
+class _SelectedGuardianListElementState extends State<SelectedGuardianListElement> {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      child: Card(
+        elevation: 8,
+        clipBehavior: Clip.antiAliasWithSaveLayer,
+        child: InkWell(
+          onTap: widget.onButtonPressed,
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              children: [
+                // 並び替え用のドラッグハンドルアイコンを追加
+                ReorderableDragStartListener(
+                  index: widget.order - 1, // orderは1ベースなので、0ベースのindexに変換
+                  child: const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 8.0),
+                    child: Icon(Icons.drag_handle),
+                  ),
+                ),
+                NumberIcon(number: widget.order, color: Colors.indigo,), // 順序番号アイコン
+                SizedBox(width: 16),
+                titleText(widget.title,),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+  Widget addButton() {
+    // ボタンの表示をカスタマイズする場合はここで変更
+    return IconButton(
+      onPressed: widget.onButtonPressed,
+      icon: const Icon(Icons.add),
+    );
+  }
+
+  Text titleText(String title) {
+    return Text(
+      title,
+      style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+    );
+  }
+
+  Padding listElementPadding(Widget child) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: child,
+    );
+  }
+}

--- a/frontend/where_child_bus/lib/components/util/number_icon.dart
+++ b/frontend/where_child_bus/lib/components/util/number_icon.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class NumberIcon extends StatelessWidget {
+  final int number; // 表示する数字
+  final IconData icon; // 使用するアイコン
+  final Color color; // アイコンの色
+  final double size; // アイコンのサイズ
+
+  const NumberIcon({
+    Key? key,
+    required this.number,
+    this.icon = Icons.circle, // デフォルトのアイコン
+    this.color = Colors.blue, // デフォルトの色
+    this.size = 24.0, // デフォルトのサイズ
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        Icon(
+          icon,
+          color: color,
+          size: size,
+        ),
+        Positioned(
+          right: 0,
+          child: Container(
+            padding: const EdgeInsets.all(1),
+            decoration: BoxDecoration(
+              color: Colors.red,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            constraints: const BoxConstraints(
+              minWidth: 12,
+              minHeight: 12,
+            ),
+            child: Text(
+              '$number',
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 8,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/where_child_bus/lib/components/util/number_icon.dart
+++ b/frontend/where_child_bus/lib/components/util/number_icon.dart
@@ -2,51 +2,39 @@ import 'package:flutter/material.dart';
 
 class NumberIcon extends StatelessWidget {
   final int number; // 表示する数字
-  final IconData icon; // 使用するアイコン
-  final Color color; // アイコンの色
-  final double size; // アイコンのサイズ
+  final Color color; // テキストの色
+  final double size; // テキストのサイズ
 
   const NumberIcon({
     Key? key,
     required this.number,
-    this.icon = Icons.circle, // デフォルトのアイコン
     this.color = Colors.blue, // デフォルトの色
     this.size = 24.0, // デフォルトのサイズ
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      alignment: Alignment.center,
-      children: [
-        Icon(
-          icon,
-          color: color,
-          size: size,
-        ),
-        Positioned(
-          right: 0,
-          child: Container(
-            padding: const EdgeInsets.all(1),
-            decoration: BoxDecoration(
-              color: Colors.red,
-              borderRadius: BorderRadius.circular(6),
-            ),
-            constraints: const BoxConstraints(
-              minWidth: 12,
-              minHeight: 12,
-            ),
-            child: Text(
-              '$number',
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 8,
-              ),
-              textAlign: TextAlign.center,
-            ),
+    // 円形にするためにサイズを計算
+    double circleDiameter = size + 16; // sizeに基づいて適切な直径を計算
+
+    return Container(
+      width: circleDiameter, // 幅と高さを同じにして正方形に
+      height: circleDiameter,
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.2), // 背景色
+        borderRadius: BorderRadius.circular(circleDiameter / 2), // 角を完全に丸くして円形に
+      ),
+      child: Center( // Textウィジェットを中央に配置
+        child: Text(
+          '$number',
+          style: TextStyle(
+            color: color,
+            fontSize: size,
+            fontWeight: FontWeight.bold,
           ),
+          textAlign: TextAlign.center,
         ),
-      ],
+      ),
     );
   }
 }

--- a/frontend/where_child_bus/lib/pages/auth_page/auth_page.dart
+++ b/frontend/where_child_bus/lib/pages/auth_page/auth_page.dart
@@ -121,9 +121,16 @@ class _AuthPageState extends State<AuthPage> {
 
   login() async {
     BuildContext currentContext = context;
+    NurseryLoginResponse res;
     try {
-      NurseryLoginResponse res = await nurseryLogin(
-          _emailController.text, _passwordController.text);
+      if(kDebugMode) {
+        res = await nurseryLogin(
+            "demo@example.com", "password");
+      } else {
+        res = await nurseryLogin(
+            _emailController.text, _passwordController.text);
+      }
+
       
       if (res.success) {
         print(res.success);

--- a/frontend/where_child_bus/lib/pages/bus_list_page/bus_edit_page/bus_child_manage_page/bus_guardian_manage_page.dart
+++ b/frontend/where_child_bus/lib/pages/bus_list_page/bus_edit_page/bus_child_manage_page/bus_guardian_manage_page.dart
@@ -9,8 +9,13 @@ class BusGuardianManagePage extends StatefulWidget {
 
 class _BusGuardianManagePageState extends State<BusGuardianManagePage> {
   // サンプルデータのリスト
-  final List<String> guardianNames = ['保護者1', '保護者2', '保護者3'];
-  final List<String> groupNames = ['グループA', 'グループB', 'グループC'];
+  final List<String> morningGuardianNames = ['保護者1', '保護者2', '保護者3'];
+  final List<String> eveningGuardianNames = ['保護者1', '保護者2', '保護者3'];
+  final List<String> morningGroupNames = ['グループA', 'グループB', 'グループC'];
+  final List<String> eveningGroupNames = ['グループA', 'グループB', 'グループC'];
+  List<String> morningAddedGuardians = [];
+  List<String> eveningAddedGuardians = [];
+
 
   @override
   Widget build(BuildContext context) {
@@ -45,16 +50,27 @@ class _BusGuardianManagePageState extends State<BusGuardianManagePage> {
             ],
           ),
         ),
-        ConfirmButton(buttonText: "保存"),
+        SizedBox(
+          height: 100,
+          child: ConfirmButton(buttonText: "保存")
+        ),
       ],
     );
   }
 
   Widget morningGuardianList() {
-    return GuardianList(guardianNames: guardianNames, groupNames: groupNames);
+    return GuardianList(
+      guardianNames: morningGuardianNames, 
+      groupNames: morningGroupNames, 
+      addedGuardians: morningAddedGuardians
+    );
   }
 
   Widget eveningGuardianList() {
-    return GuardianList(guardianNames: guardianNames, groupNames: groupNames);
+    return GuardianList(
+      guardianNames: eveningGuardianNames, 
+      groupNames: eveningGroupNames, 
+      addedGuardians: eveningAddedGuardians
+    );
   }
 }

--- a/frontend/where_child_bus/lib/pages/bus_list_page/bus_edit_page/bus_child_manage_page/bus_guardian_manage_page.dart
+++ b/frontend/where_child_bus/lib/pages/bus_list_page/bus_edit_page/bus_child_manage_page/bus_guardian_manage_page.dart
@@ -1,0 +1,60 @@
+import "package:flutter/material.dart";
+import "package:where_child_bus/components/guardian_list/guardian_list.dart";
+import "package:where_child_bus/pages/bus_list_page/bus_edit_page/components/confirm_button.dart";
+
+class BusGuardianManagePage extends StatefulWidget {
+  @override
+  _BusGuardianManagePageState createState() => _BusGuardianManagePageState();  
+}
+
+class _BusGuardianManagePageState extends State<BusGuardianManagePage> {
+  // サンプルデータのリスト
+  final List<String> guardianNames = ['保護者1', '保護者2', '保護者3'];
+  final List<String> groupNames = ['グループA', 'グループB', 'グループC'];
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: pageAppBar(),
+        body: pageBody(),
+      ),
+    );
+  }
+
+  AppBar pageAppBar() {
+    return AppBar(
+      bottom : const TabBar(
+        tabs: [
+          Tab(text: "昼",),
+          Tab(text: "夜",),
+        ],
+      )
+    );
+  }
+
+  Widget pageBody() {
+    return  Column(
+      children: [
+        Expanded(
+          child: TabBarView(
+            children: [
+              morningGuardianList(),
+              eveningGuardianList(),
+            ],
+          ),
+        ),
+        ConfirmButton(buttonText: "保存"),
+      ],
+    );
+  }
+
+  Widget morningGuardianList() {
+    return GuardianList(guardianNames: guardianNames, groupNames: groupNames);
+  }
+
+  Widget eveningGuardianList() {
+    return GuardianList(guardianNames: guardianNames, groupNames: groupNames);
+  }
+}

--- a/frontend/where_child_bus/lib/pages/bus_list_page/bus_edit_page/bus_child_manage_page/bus_guardian_manage_page.dart
+++ b/frontend/where_child_bus/lib/pages/bus_list_page/bus_edit_page/bus_child_manage_page/bus_guardian_manage_page.dart
@@ -9,10 +9,34 @@ class BusGuardianManagePage extends StatefulWidget {
 
 class _BusGuardianManagePageState extends State<BusGuardianManagePage> {
   // サンプルデータのリスト
-  final List<String> morningGuardianNames = ['保護者1', '保護者2', '保護者3'];
-  final List<String> eveningGuardianNames = ['保護者1', '保護者2', '保護者3'];
-  final List<String> morningGroupNames = ['グループA', 'グループB', 'グループC'];
-  final List<String> eveningGroupNames = ['グループA', 'グループB', 'グループC'];
+  final List<String> morningGuardianNames = [
+    '保護者1', '保護者2', '保護者3', '保護者4', '保護者5',
+    '保護者6', '保護者7', '保護者8', '保護者9', '保護者10',
+    '保護者11', '保護者12', '保護者13', '保護者14', '保護者15',
+    '保護者16', '保護者17', '保護者18', '保護者19', '保護者20',
+  ];
+
+  final List<String> eveningGuardianNames = [
+    '保護者1', '保護者2', '保護者3', '保護者4', '保護者5',
+    '保護者6', '保護者7', '保護者8', '保護者9', '保護者10',
+    '保護者11', '保護者12', '保護者13', '保護者14', '保護者15',
+    '保護者16', '保護者17', '保護者18', '保護者19', '保護者20',
+  ];
+
+  final List<String> morningGroupNames = [
+    'グループA', 'グループB', 'グループC', 'グループD', 'グループE',
+    'グループF', 'グループG', 'グループH', 'グループI', 'グループJ',
+    'グループK', 'グループL', 'グループM', 'グループN', 'グループO',
+    'グループP', 'グループQ', 'グループR', 'グループS', 'グループT',
+  ];
+
+  final List<String> eveningGroupNames = [
+    'グループA', 'グループB', 'グループC', 'グループD', 'グループE',
+    'グループF', 'グループG', 'グループH', 'グループI', 'グループJ',
+    'グループK', 'グループL', 'グループM', 'グループN', 'グループO',
+    'グループP', 'グループQ', 'グループR', 'グループS', 'グループT',
+  ];
+
   List<String> morningAddedGuardians = [];
   List<String> eveningAddedGuardians = [];
 

--- a/frontend/where_child_bus/lib/pages/bus_list_page/bus_edit_page/bus_edit_page.dart
+++ b/frontend/where_child_bus/lib/pages/bus_list_page/bus_edit_page/bus_edit_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:where_child_bus/pages/bus_list_page/bus_edit_page/bus_child_manage_page/bus_child_manage_page.dart';
+import 'package:where_child_bus/pages/bus_list_page/bus_edit_page/bus_child_manage_page/bus_guardian_manage_page.dart';
 import 'package:where_child_bus/pages/bus_list_page/bus_edit_page/components/confirm_button.dart';
 import 'package:where_child_bus/pages/bus_list_page/bus_edit_page/components/input_element.dart';
 import 'package:where_child_bus/pages/bus_list_page/bus_edit_page/components/stations_list.dart';
@@ -109,10 +110,10 @@ class _BusEditPage extends State<BusEditPage> {
         child: ElevatedButton(
           onPressed: () {
             Navigator.push(
-                context,MaterialPageRoute(builder: (context) => BusChildManagePage())
+                context,MaterialPageRoute(builder: (context) => BusGuardianManagePage())
               ); 
           }, 
-          child: const Text("バスに乗車する子供を変更"),
+          child: const Text("バスを利用する保護者を変更"),
         ),
       ),
     );


### PR DESCRIPTION
## チケットへのリンク

https://github.com/GreenTeaProgrammers/WhereChildBus/issues/58

## やったこと
バス追加/編集の際に使う保護者一覧表示画面を作成
## やらないこと
バックエンドとの通信
## できるようになること（ユーザ目線）
バスに紐づける保護者が選択できる
## できなくなること（ユーザ目線）
なし
## 動作確認
androidエミュレータで動作確認
## その他
なし