### PR TITLE
fix:iphoneからのストリーミングを修正

### DIFF
--- a/frontend/where_child_bus/lib/pages/camera_page/camera_page.dart
+++ b/frontend/where_child_bus/lib/pages/camera_page/camera_page.dart
@@ -42,6 +42,8 @@ class _CameraPageState extends State<CameraPage> {
       await _controller.initialize();
       if (!mounted) return;
       setState(() {});
+      developer.log("Camera aspect ratio: ${_controller.value.aspectRatio}",
+          name: "CameraPage");
       _startImageStream();
       developer.log("Start streaming video to server", name: "CameraPage");
       streamBusVideo(_streamController.stream);
@@ -148,26 +150,26 @@ class _CameraPageState extends State<CameraPage> {
   }
 
   Widget _createPageBody() {
-    return Expanded(
-      child: Stack(
-        children: [
-          AspectRatio(
-              aspectRatio: _controller.value.aspectRatio,
+    return Stack(
+      children: [
+        Center(
+          child: AspectRatio(
+              aspectRatio: 1 / _controller.value.aspectRatio,
               child: CameraPreview(_controller)),
-          Positioned(
-              right: 15,
-              child: RidingToggle(
-                  onToggled: (event) => {
-                        setState(() {
-                          if (event) {
-                            _vehicleEvent = VehicleEvent.VEHICLE_EVENT_GET_ON;
-                          } else {
-                            _vehicleEvent = VehicleEvent.VEHICLE_EVENT_GET_OFF;
-                          }
-                        }),
-                      }))
-        ],
-      ),
+        ),
+        Positioned(
+            right: 15,
+            child: RidingToggle(
+                onToggled: (event) => {
+                      setState(() {
+                        if (event) {
+                          _vehicleEvent = VehicleEvent.VEHICLE_EVENT_GET_ON;
+                        } else {
+                          _vehicleEvent = VehicleEvent.VEHICLE_EVENT_GET_OFF;
+                        }
+                      }),
+                    }))
+      ],
     );
   }
 }

--- a/frontend/where_child_bus/lib/pages/camera_page/camera_page.dart
+++ b/frontend/where_child_bus/lib/pages/camera_page/camera_page.dart
@@ -148,22 +148,26 @@ class _CameraPageState extends State<CameraPage> {
   }
 
   Widget _createPageBody() {
-    return Stack(
-      children: [
-        CameraPreview(_controller),
-        Positioned(
-            right: 15,
-            child: RidingToggle(
-                onToggled: (event) => {
-                      setState(() {
-                        if (event) {
-                          _vehicleEvent = VehicleEvent.VEHICLE_EVENT_GET_ON;
-                        } else {
-                          _vehicleEvent = VehicleEvent.VEHICLE_EVENT_GET_OFF;
-                        }
-                      }),
-                    }))
-      ],
+    return Expanded(
+      child: Stack(
+        children: [
+          AspectRatio(
+              aspectRatio: _controller.value.aspectRatio,
+              child: CameraPreview(_controller)),
+          Positioned(
+              right: 15,
+              child: RidingToggle(
+                  onToggled: (event) => {
+                        setState(() {
+                          if (event) {
+                            _vehicleEvent = VehicleEvent.VEHICLE_EVENT_GET_ON;
+                          } else {
+                            _vehicleEvent = VehicleEvent.VEHICLE_EVENT_GET_OFF;
+                          }
+                        }),
+                      }))
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## チケットへのリンク

## やったこと
iphoneから送信される画像をグレースケールに修正
## やらないこと
なし
## できるようになること（ユーザ目線）
iphoneから画像のストリーミング
## できなくなること（ユーザ目線）
なし
## 動作確認
iphoneから確認
## その他
なし