### PR TITLE
chore: 保護者側アプリのタイトルを修正

### DIFF
--- a/frontend/where_child_bus_guardian/lib/main.dart
+++ b/frontend/where_child_bus_guardian/lib/main.dart
@@ -34,7 +34,7 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'WhereChildBus Guardian',
+      title: 'hoicruise guardian',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textTheme: GoogleFonts.hachiMaruPopTextTheme(

--- a/frontend/where_child_bus_guardian/lib/pages/auth_page/auth_page.dart
+++ b/frontend/where_child_bus_guardian/lib/pages/auth_page/auth_page.dart
@@ -85,7 +85,7 @@ class _AuthPageState extends State<AuthPage> {
 
   Widget titleText() => const Padding(
         padding: EdgeInsets.only(bottom: 32),
-        child: Text('WhereChildBus',
+        child: Text('ほいくるーず',
             style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold)),
       );
 


### PR DESCRIPTION
## チケットへのリンク

-なし

## やったこと

- 保護者側アプリのタイトルを「ほいくるーず」に変更しました。

## やらないこと

- なし

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

-Androidエミュレータで動作確認済み

## その他

- なし