### PR TITLE
fix: フォトフレームが読み込まれない致命的なエラーを解消

### DIFF
--- a/frontend/where_child_bus_guardian/pubspec.lock
+++ b/frontend/where_child_bus_guardian/pubspec.lock
@@ -312,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   js:
     dependency: transitive
     description:

--- a/frontend/where_child_bus_guardian/pubspec.yaml
+++ b/frontend/where_child_bus_guardian/pubspec.yaml
@@ -35,4 +35,5 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
+    - assets/images/
     - .env


### PR DESCRIPTION
## チケットへのリンク

- なし

## やったこと

- assets/images/が読み込まれない致命的なエラーを解消しました。

## やらないこと

- なし

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし
## 動作確認

-Androidエミュレータで動作確認済み

## その他

- なし
