### PR TITLE
fix: channelを閉じる場所を修正

### DIFF
--- a/frontend/where_child_bus_guardian/lib/util/api/guardian.dart
+++ b/frontend/where_child_bus_guardian/lib/util/api/guardian.dart
@@ -28,8 +28,9 @@ Future<GuardianLoginResponse> guardianLogin(
     return res;
   } catch (error) {
     developer.log("Caught Error", error: error);
-    await channel.shutdown();
     return Future.error(error);
+  } finally {
+    await channel.shutdown();
   }
 }
 

--- a/frontend/where_child_bus_guardian/lib/util/api/health_check.dart
+++ b/frontend/where_child_bus_guardian/lib/util/api/health_check.dart
@@ -22,7 +22,8 @@ Future<PingResponse> serviceHealthCheck() async {
     return res;
   } catch (error) {
     developer.log('Caught error: $error');
-    await channel.shutdown();
     return Future.error(error);
+  } finally {
+    await channel.shutdown();
   }
 }


### PR DESCRIPTION
## チケットへのリンク

- なし

## やったこと

- channelを閉じる場所を変更し、必ず閉じられるよう修正しました。

## やらないこと

- なし

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

- Androidエミュレータで動作確認済み

## その他

- なし
